### PR TITLE
Various improvements

### DIFF
--- a/cmd/unsocket/main.go
+++ b/cmd/unsocket/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	err := cmd.Execute()
 	if err != nil {
-
+		os.Exit(1)
 	}
 }
 

--- a/cmd/unsocket/main.go
+++ b/cmd/unsocket/main.go
@@ -15,6 +15,8 @@ var (
 )
 
 func main() {
+	log.SetFormatter(&log.JSONFormatter{})
+
 	var cmd = &cobra.Command{
 		Use:   "unsocket [webhook]",
 		Short: "unsocket",

--- a/unsocket.go
+++ b/unsocket.go
@@ -102,6 +102,8 @@ func (u *Unsocket) RunAndWait() error {
 
 			log.Info("processing websocket message")
 
+			log.Info(string(text))
+
 			res, err := u.httpClient.request([]*messages.Message{
 				&messages.NewText(&messages.TextData{
 					Text: string(text),

--- a/unsocket.go
+++ b/unsocket.go
@@ -91,6 +91,8 @@ func (u *Unsocket) RunAndWait() error {
 		}
 
 		select {
+		case <-wsClient.error:
+			return errors.New("Websocket client exited with an error")
 		case <-u.done:
 			goto Escape
 		case text := <-wsClient.receive:

--- a/ws_client.go
+++ b/ws_client.go
@@ -3,6 +3,7 @@ package unsocket
 import (
 	"fmt"
 	"github.com/gorilla/websocket"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 
@@ -75,7 +76,9 @@ func (c *wsClient) readPump() {
 	for {
 		_, message, err := c.conn.ReadMessage()
 		if err != nil {
+			log.Errorf("error reading message: %v", err)
 			close(c.done)
+			return
 		}
 
 		if message != nil {

--- a/ws_client.go
+++ b/ws_client.go
@@ -28,6 +28,8 @@ type wsClient struct {
 	receive chan []byte
 	// done channel acts as shutdown signal
 	done chan struct{}
+	// error channel allows to signal an error from go routines
+	error chan struct{}
 }
 
 type wsClientConfig struct {
@@ -50,6 +52,7 @@ func (c *wsClient) RunAndWait() error {
 
 	// initialize new done channel to act as shutdown signal
 	c.done = make(chan struct{})
+	c.error = make(chan struct{})
 
 	c.send = make(chan []byte)
 	c.receive = make(chan []byte)
@@ -78,6 +81,7 @@ func (c *wsClient) readPump() {
 
 		if err != nil {
 			log.Errorf("error reading message: %v", err)
+			close(c.error)
 			close(c.done)
 			return
 		}

--- a/ws_client.go
+++ b/ws_client.go
@@ -69,12 +69,13 @@ func (c *wsClient) handlePong(message string) error {
 }
 
 func (c *wsClient) readPump() {
-	// c.conn.SetReadLimit(maxMessageSize)
-	c.conn.SetReadDeadline(time.Now().Add(pongWait))
 	c.conn.SetPongHandler(c.handlePong)
 
 	for {
 		_, message, err := c.conn.ReadMessage()
+
+		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+
 		if err != nil {
 			log.Errorf("error reading message: %v", err)
 			close(c.done)


### PR DESCRIPTION
- [x] quit infinite loop to prevent closing a channel twice
- [x] use logrus with json fromat to allow GCP Logs to parse timestamps and level
- [x] renew timeout value also on normal messages (not only on pong)
- [x] verbosely log messages (temporary to understand Kraken fields better)
- [x] Exist with non-zero exit code if errors happened