### PR TITLE
Turn http requests into websocket messages

### DIFF
--- a/cmd/unsocket/main.go
+++ b/cmd/unsocket/main.go
@@ -13,6 +13,7 @@ import (
 var (
 	verbose = false
 	port = 8080
+	webhookSecret = ""
 )
 
 func main() {
@@ -34,6 +35,7 @@ func main() {
 
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	cmd.PersistentFlags().IntVarP(&port, "port", "p", 8080, "port for the webserver to bind to")
+	cmd.PersistentFlags().StringVar(&webhookSecret, "webhook-secret", envOrDefault("WEBHOOK_SECRET", webhookSecret), "webhook client secret")
 
 	err := cmd.Execute()
 	if err != nil {
@@ -52,6 +54,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	unsock, err := unsocket.NewUnsocket(&unsocket.Config{
 		WebhookURL: args[0],
+		WebhookSecret: webhookSecret,
 		WebserverPort: port,
 	})
 	if err != nil {
@@ -75,4 +78,13 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// signal successful execution
 	return nil
+}
+
+func envOrDefault(key string, def string) string {
+	value := os.Getenv(key)
+	if value == "" {
+
+		return def
+	}
+	return value
 }

--- a/cmd/unsocket/main.go
+++ b/cmd/unsocket/main.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	verbose = false
+	port = 8080
 )
 
 func main() {
@@ -32,6 +33,7 @@ func main() {
 	}
 
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	cmd.PersistentFlags().IntVarP(&port, "port", "p", 8080, "port for the webserver to bind to")
 
 	err := cmd.Execute()
 	if err != nil {
@@ -50,6 +52,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	unsock, err := unsocket.NewUnsocket(&unsocket.Config{
 		WebhookURL: args[0],
+		WebserverPort: port,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create unsocket: %w", err)

--- a/http_client.go
+++ b/http_client.go
@@ -8,17 +8,20 @@ import (
 
 type httpClient struct {
 	client *resty.Client
-	url    string
+	url    			string
+	webhookSecret	string
 }
 
 type httpClientConfig struct {
-	url string
+	url				string
+	webhookSecret	string
 }
 
 func newHTTPClient(config *httpClientConfig) *httpClient {
 	return &httpClient{
 		client: resty.New(),
 		url:    config.url,
+		webhookSecret: config.webhookSecret,
 	}
 }
 
@@ -34,8 +37,14 @@ func (c *httpClient) request(msgs []*messages.Message) (*httpClientResponse, err
 		Messages []*messages.Message `json:"messages"`
 	}
 
+	headers := map[string]string{ "Content-Type":  "application/json" }
+
+	if len(c.webhookSecret) > 0 {
+		headers["Authorization"] = "Bearer " + c.webhookSecret
+	}
+
 	res, err := c.client.R().
-		SetHeader("Content-Type", "application/json").
+		SetHeaders(headers).
 		SetBody(&request{
 			Messages: msgs,
 		}).

--- a/messages/types.go
+++ b/messages/types.go
@@ -30,6 +30,7 @@ type Ready struct {
 
 type ConnectData struct {
 	URL string `json:"url"`
+	Headers map[string]string `json:"headers"`
 }
 type Connect struct {
 	Message

--- a/messages/types.go
+++ b/messages/types.go
@@ -84,7 +84,7 @@ func NewText(data *TextData) *Text {
 }
 
 func NewExclude(data *ExcludeData) *Exclude {
-	message := Exclude{Message: Message{Type: ConnectType}, ExcludeData: data}
+	message := Exclude{Message: Message{Type: ExcludeType}, ExcludeData: data}
 	message.Message.self = &message
 	return &message
 }

--- a/unsocket.go
+++ b/unsocket.go
@@ -60,8 +60,15 @@ func (u *Unsocket) RunAndWait() error {
 
 	log.Infof("connecting to %s", connect.URL)
 
+	headers := make(map[string][]string)
+
+	for key, value := range connect.Headers {
+		headers[key] = []string{value}
+	}
+
 	wsClient := newWSClient(&wsClientConfig{
 		url: connect.URL,
+		header: headers,
 	})
 
 	err = wsClient.RunAndWait()

--- a/unsocket.go
+++ b/unsocket.go
@@ -11,6 +11,7 @@ import (
 
 type Config struct {
 	WebhookURL string
+	WebhookSecret string
 	WebserverPort int
 }
 
@@ -26,6 +27,7 @@ type Unsocket struct {
 func NewUnsocket(config *Config) (*Unsocket, error) {
 	httpClient := newHTTPClient(&httpClientConfig{
 		url: config.WebhookURL,
+		webhookSecret: config.WebhookSecret,
 	})
 
 	webserver := newWebserver(&webserverConfig{

--- a/unsocket.go
+++ b/unsocket.go
@@ -11,6 +11,7 @@ import (
 
 type Config struct {
 	WebhookURL string
+	WebserverPort int
 }
 
 type Unsocket struct {
@@ -27,7 +28,9 @@ func NewUnsocket(config *Config) (*Unsocket, error) {
 		url: config.WebhookURL,
 	})
 
-	webserver := newWebserver()
+	webserver := newWebserver(&webserverConfig{
+		port: config.WebserverPort,
+	})
 
 	return &Unsocket{
 		httpClient: httpClient,

--- a/webserver.go
+++ b/webserver.go
@@ -1,0 +1,75 @@
+package unsocket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/unsocket/unsocket/messages"
+)
+
+type webserver struct {
+	srv    	*http.Server
+	error chan struct{}
+	receive chan messages.Text
+}
+
+func newWebserver() *webserver {
+	return &webserver{
+		srv: &http.Server{
+			Addr: ":3009",
+		},
+		error: make(chan struct{}),
+	}
+}
+
+func (c *webserver) RunAndWait() error {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		var bodyBytes []byte
+		var err error
+		if r.Body != nil {
+			bodyBytes, err = ioutil.ReadAll(r.Body)
+			if err != nil {
+				fmt.Printf("Body reading error: %v", err)
+				return
+			}
+			defer r.Body.Close()
+		}
+
+	    m := messages.Text{}
+	    if err := m.UnmarshalJSON(bodyBytes); err == nil {
+		    c.receive <- m
+		} else{
+			log.Errorf("Error during unmarshal: %v", err)
+			http.Error(w, "unsupported message type", 422)
+		}
+    })
+
+	c.receive = make(chan messages.Text)
+
+    log.Printf("starting to listen on %v", c.srv.Addr)
+
+    go c.listen()
+
+    return nil
+}
+
+func (c *webserver) listen() {
+	err := c.srv.ListenAndServe()
+
+	if errors.Is(err, http.ErrServerClosed) {
+		log.Printf("webserver closed")
+	} else if err != nil {
+		log.Printf("error starting web server: %s\n", err)
+		c.error <- struct{}{}
+	}
+}
+
+func (c *webserver) Stop() {
+	if err := c.srv.Shutdown(context.Background()); err != nil {
+		log.Printf("HTTP server Shutdown: %v", err)
+	}
+}

--- a/webserver.go
+++ b/webserver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/unsocket/unsocket/messages"
@@ -17,10 +18,14 @@ type webserver struct {
 	receive chan messages.Text
 }
 
-func newWebserver() *webserver {
+type webserverConfig struct {
+	port	int
+}
+
+func newWebserver(config *webserverConfig) *webserver {
 	return &webserver{
 		srv: &http.Server{
-			Addr: ":3009",
+			Addr: fmt.Sprintf(":%v", strconv.Itoa(config.port)),
 		},
 		error: make(chan struct{}),
 	}

--- a/webserver.go
+++ b/webserver.go
@@ -27,7 +27,7 @@ func newWebserver() *webserver {
 }
 
 func (c *webserver) RunAndWait() error {
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/message", func(w http.ResponseWriter, r *http.Request) {
 		var bodyBytes []byte
 		var err error
 		if r.Body != nil {

--- a/ws_client.go
+++ b/ws_client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 	"time"
+	"net/http"
 )
 
 const (
@@ -23,6 +24,7 @@ const (
 
 type wsClient struct {
 	url     string
+	header	http.Header
 	conn    *websocket.Conn
 	send    chan []byte
 	receive chan []byte
@@ -34,16 +36,18 @@ type wsClient struct {
 
 type wsClientConfig struct {
 	url string
+	header http.Header
 }
 
 func newWSClient(config *wsClientConfig) *wsClient {
 	return &wsClient{
 		url: config.url,
+		header: config.header,
 	}
 }
 
 func (c *wsClient) RunAndWait() error {
-	conn, _, err := websocket.DefaultDialer.Dial(c.url, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(c.url, c.header)
 	if err != nil {
 		return fmt.Errorf("unable to establish websocket connection: %w", err)
 	}


### PR DESCRIPTION
Completes step (8) and (9) outlined in the README. 

- [x] fixes tiny issue 4cc10ec08b51e8b2b729733d25f7b67b13d5063f
- [x] allows webhook endpoint to return http headers to be used when connecting to websocket 981a260c542a7a9e45e49cae2947592caad93b62
- [x] forward messages received on `/message`